### PR TITLE
typo colums > columns

### DIFF
--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -15,7 +15,7 @@ export const Projects = () => {
 					</div>
 				</div>
 				<h1>Commissions</h1>
-				<div className="colums">
+				<div className="columns">
 					<div className="column is-full">
 						<p
 							style={{


### PR DESCRIPTION
Was looking at some open source React projects and noticed this typo. Nice website!